### PR TITLE
feat!: remove mapping to id from _id

### DIFF
--- a/adapter_test.js
+++ b/adapter_test.js
@@ -174,8 +174,6 @@ test("retrieve document", async () => {
   });
   assertEquals(result.hello, "world");
   assertEquals(result._id, "1");
-  // TODO: remove when blueberry is released
-  assertEquals(result.id, result._id);
 });
 
 test("find documents", async () => {
@@ -192,9 +190,6 @@ test("find documents", async () => {
     _id: "1",
     hello: "world",
   });
-
-  // TODO: remove when blueberry is released
-  assertEquals(results.docs[0].id, results.docs[0]._id);
 });
 
 test("create query index", async () => {
@@ -216,7 +211,4 @@ test("list documents", async () => {
     _id: "1",
     hello: "world",
   });
-
-  // TODO: remove when blueberry is released
-  assertEquals(results.docs[0].id, results.docs[0]._id);
 });

--- a/scripts/hyper-test.sh
+++ b/scripts/hyper-test.sh
@@ -1,1 +1,1 @@
-deno test --allow-net --allow-env --no-check --import-map=https://x.nest.land/hyper-test@0.0.4/import_map.json https://x.nest.land/hyper-test@0.0.4/mod.js
+deno test --allow-net --allow-env --no-check --import-map=https://x.nest.land/hyper-test@2.0.0/import_map.json https://x.nest.land/hyper-test@2.0.0/mod.js


### PR DESCRIPTION
Any consumer that depended on `id` may break, _if_ an actual `id` field
doesn't exist on the document.

I propose we major bump to `v2.0.0` when this is merged.

BREAKING CHANGE

These changes pass the `hyper-test` suite ~[pending review](https://github.com/hyper63/hyper/pull/423)~

Closes #24 